### PR TITLE
HideSkeletonName

### DIFF
--- a/UltimateHUD/Config.cs
+++ b/UltimateHUD/Config.cs
@@ -68,6 +68,8 @@ namespace UltimateHUD
         [Description("You can use {displayname} instead of {nickname}")]
         public string SpectatorHud { get; set; } = "<color=#808080><b>Spectating:</b> <color=white>{nickname}</color> <b>|</b> <b>ID:</b> <color=white>{id}</color> <b>|</b> <b>Role:</b> {role} <b>| Kills:</b> <color=yellow>{kills}</color></color>";
         public int SpectatorHudFontSize { get; set; } = 33;
+        [Description("If true, will not show the spectated player's nickname when they are a skeleton (SCP-3114). This mimics the behavior of the base-game spectator UI.")]
+        public bool HideSkeletonNickname { get; set; } = true;
 
         [Description("Spectator Map Info:")]
         public bool EnableSpectatorMapInfo { get; set; } = true;

--- a/UltimateHUD/Hints.cs
+++ b/UltimateHUD/Hints.cs
@@ -320,6 +320,9 @@ namespace UltimateHUD
                         string coloredObservedRole = $"<color={observedRoleColor}>{observedRole}</color>";
                         int observedKills = EventHandlers.GetKills(observed);
 
+                        if (Config.HideSkeletonNickname && observed.Role.Type == RoleTypeId.Scp3114)
+                            observedNickname = observedRole;
+
                         return Config.SpectatorHud
                             .Replace("{nickname}", observedNickname)
                             .Replace("{displayname}", observedDisplayname)


### PR DESCRIPTION
Added configurable HideSkeletonName option:

- When enabled, if a Spectator is spectating a Skeleton (SCP-3114), the "Nickname: " section of the spectate UI will just show the RoleTypeId translation instead.
- In other words, you see "Nickname: SCP-3114".
- This mimics the behavior of the spectator's player list UI in the base game, which does not normally reveal the identity of the Skeleton player.
- For that reason, I made the setting default to true, but if you want to default it to false, that's fine too.